### PR TITLE
Factor out the documentation system.

### DIFF
--- a/generator.lisp
+++ b/generator.lisp
@@ -17,6 +17,7 @@
 (defun (setf global-generator) (value name)
   (setf (gethash name *generators*) value))
 
+#-allegro
 (define-compiler-macro global-generator (&whole whole name &environment env)
   (if (constantp name env)
       `(load-time-value (or (gethash ,name *generators*)

--- a/random-state.asd
+++ b/random-state.asd
@@ -26,5 +26,8 @@
                (:file "kiss")
                (:file "squirrel")
                (:file "implementation")
-               (:file "documentation"))
-  :depends-on (:documentation-utils))
+               ))
+
+(asdf:defsystem "random-state/documentation"
+    :depends-on ("random-state" :documentation-utils)
+  :components ((:file "documentation")))


### PR DESCRIPTION
I'd like to factor the documentation out of the main system so that we can use random-state without the dependency tail that comes from the documentation builder.

What I did was to pull the documentation out into "random-state/documentation" slashy system.
