### PR TITLE
Tweak to generator.lisp and protocol.lisp to eliminate style-warnings

### DIFF
--- a/generator.lisp
+++ b/generator.lisp
@@ -74,7 +74,10 @@
       whole))
 
 (defgeneric %make-generator (type &key))
-(define-generator-fun seed (generator))
+#+sbcl
+(locally (declare (sb-ext:muffle-conditions style-warning))
+  (define-generator-fun seed (generator)))
+#-sbcl (define-generator-fun seed (generator))
 (define-generator-fun reseed (generator new-seed))
 (define-generator-fun next-byte (generator))
 (define-generator-fun bits-per-byte (generator))

--- a/generator.lisp
+++ b/generator.lisp
@@ -17,6 +17,7 @@
 (defun (setf global-generator) (value name)
   (setf (gethash name *generators*) value))
 
+#-allegro
 (define-compiler-macro global-generator (&whole whole name &environment env)
   (if (constantp name env)
       `(load-time-value (or (gethash ,name *generators*)

--- a/implementation.lisp
+++ b/implementation.lisp
@@ -34,3 +34,5 @@
 
 (defmethod copy ((generator random-state))
   (make-random-state generator))
+
+(defvar *generator* (make-generator :random-state))

--- a/package.lisp
+++ b/package.lisp
@@ -11,6 +11,7 @@ Author: Nicolas Hafner <shinmera@tymoon.eu>
   (:shadow #:random)
   ;; generator.lisp
   (:export
+   #:*generator*
    #:global-generator
    #:ensure-generator
    #:list-generator-types

--- a/protocol.lisp
+++ b/protocol.lisp
@@ -2,6 +2,7 @@
  This file is a part of random-state
  (c) 2015 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
  Author: Nicolas Hafner <shinmera@tymoon.eu>
+ Modifications (c) 2023 Robert P. Goldman
 |#
 
 (in-package #:org.shirakumo.random-state)
@@ -9,18 +10,7 @@
 (declaim (special *generator*) (type (or generator random-state) *generator*))
 
 (declaim (inline random))
-(defun random (max &optional (generator *generator*))
-  (etypecase max
-    ((integer 0)
-     (random-int generator 0 (1- max)))
-    ((short-float 0s0)
-     (random-float generator 0s0 (- max short-float-epsilon)))
-    ((single-float 0f0)
-     (random-float generator 0f0 (- max single-float-epsilon)))
-    ((double-float 0d0)
-     (random-float generator 0d0 (- max double-float-epsilon)))
-    ((long-float 0l0)
-     (random-float generator 0l0 (- max long-float-epsilon)))))
+
 
 (defun random-1d (generator index &optional (seed 0))
   (hash generator index seed))
@@ -136,3 +126,16 @@
        (loop for candidate = (random-bytes generator bits)
              when (<= candidate range)
              return candidate))))
+
+(defun random (max &optional (generator *generator*))
+  (etypecase max
+    ((integer 0)
+     (random-int generator 0 (1- max)))
+    ((short-float 0s0)
+     (random-float generator 0s0 (- max short-float-epsilon)))
+    ((single-float 0f0)
+     (random-float generator 0f0 (- max single-float-epsilon)))
+    ((double-float 0d0)
+     (random-float generator 0d0 (- max double-float-epsilon)))
+    ((long-float 0l0)
+     (random-float generator 0l0 (- max long-float-epsilon)))))

--- a/protocol.lisp
+++ b/protocol.lisp
@@ -133,9 +133,11 @@
      (random-int generator 0 (1- max)))
     ((short-float 0s0)
      (random-float generator 0s0 (- max short-float-epsilon)))
+    #-ccl ; apparently ccl's SHORT-FLOAT and SINGLE-FLOAT are the same
     ((single-float 0f0)
      (random-float generator 0f0 (- max single-float-epsilon)))
     ((double-float 0d0)
      (random-float generator 0d0 (- max double-float-epsilon)))
+    #-ccl ; apparently ccl's LONG-FLOAT and DOUBLE-FLOAT are the same
     ((long-float 0l0)
      (random-float generator 0l0 (- max long-float-epsilon)))))

--- a/protocol.lisp
+++ b/protocol.lisp
@@ -6,8 +6,10 @@
 
 (in-package #:org.shirakumo.random-state)
 
+(declaim (special *generator*) (type (or generator random-state) *generator*))
+
 (declaim (inline random))
-(defun random (max &optional (generator *random-state*))
+(defun random (max &optional (generator *generator*))
   (etypecase max
     ((integer 0)
      (random-int generator 0 (1- max)))

--- a/random-state.asd
+++ b/random-state.asd
@@ -26,5 +26,8 @@
                (:file "kiss")
                (:file "squirrel")
                (:file "implementation")
-               (:file "documentation"))
-  :depends-on (:documentation-utils))
+               ))
+
+(asdf:defsystem "random-state/documentation"
+    :depends-on ("random-state" :documentation-utils)
+  :components ((:file "documentation")))

--- a/random-state.asd
+++ b/random-state.asd
@@ -31,3 +31,8 @@
 (asdf:defsystem "random-state/documentation"
     :depends-on ("random-state" :documentation-utils)
   :components ((:file "documentation")))
+
+(asdf:defsystem "random-state/tests"
+    :depends-on ("random-state" "fiveam")
+  :components ((:file "tests"))
+    )

--- a/random-state.asd
+++ b/random-state.asd
@@ -13,6 +13,7 @@
   :bug-tracker "https://github.com/Shinmera/random-state/issues"
   :source-control (:git "https://github.com/Shinmera/random-state.git")
   :serial T
+  :in-order-to ((test-op (test-op "random-state/tests")))
   :components ((:file "package")
                (:file "toolkit")
                (:file "generator")
@@ -34,5 +35,4 @@
 
 (asdf:defsystem "random-state/tests"
     :depends-on ("random-state" "fiveam")
-  :components ((:file "tests"))
-    )
+  :components ((:file "tests")))

--- a/tests.lisp
+++ b/tests.lisp
@@ -1,0 +1,45 @@
+(defpackage random-state-tests
+  (:shadowing-import-from #:random-state #:random)
+  (:use #:random-state common-lisp #:fiveam))
+
+(in-package random-state-tests)
+
+(def-suite* random-state-tests)
+
+(def-suite* repeatability :in random-state-tests)
+
+(test import
+  (fiveam:is (eq 'random 'random-state:random))
+  (fiveam:is-false (eq 'random 'cl:random))
+  )
+
+(defmacro repeatable-generator (type)
+  (let ((test-name (intern (format nil "~A-RANDOM-REPEATABLE" type) :random-state-tests)))
+   (test ,test-name
+      (let ((new-generator (random-state:make-generator ,type (hopefully-sufficiently-random-seed)))
+            sequence1 sequence2)
+        (let ((*random-generator* (copy new-generator)))
+          (setf sequence1 (let (sequence)
+                            (dotimes (x 10)
+                              (push
+                               (random 10)
+                               sequence))
+                            sequence)))
+        (let ((*random-generator* (copy new-generator)))
+          (setf sequence2 (let (sequence)
+                            (dotimes (x 10)
+                              (push
+                               (random 10)
+                               sequence))
+                            sequence)))
+        (fiveam::is (equalp sequence1 sequence2))))))
+
+;;; don't love this code, but haven't figured out an alternative.
+(eval-when (:load-toplevel :execute)
+  (eval (cons 'progn
+              (loop for gen in (list-generator-types)
+                    collect `(repeatable-generator ,gen)))))
+
+
+
+

--- a/tests.lisp
+++ b/tests.lisp
@@ -4,6 +4,13 @@
 
 (in-package random-state-tests)
 
+(defmethod asdf:perform ((op asdf:test-op) (sys (eql (asdf:find-system "random-state/tests"))))
+  (let (success)
+    (let ((*on-failure* nil))
+      (setf success (run! 'random-state-tests)))
+    (unless success
+      (error 'asdf:operation-error :component sys :operation op))))
+
 (def-suite* random-state-tests)
 
 (def-suite* repeatability :in random-state-tests)

--- a/tests.lisp
+++ b/tests.lisp
@@ -10,35 +10,36 @@
 
 (test import
   (fiveam:is (eq 'random 'random-state:random))
-  (fiveam:is-false (eq 'random 'cl:random))
-  )
+  (fiveam:is-false (eq 'random 'cl:random)))
 
 (defmacro repeatable-generator (type)
   (let ((test-name (intern (format nil "~A-RANDOM-REPEATABLE" type) :random-state-tests)))
    `(test ,test-name
       (let ((new-generator (random-state:make-generator ,type (hopefully-sufficiently-random-seed)))
             sequence1 sequence2)
-        (let ((*random-generator* (copy new-generator)))
+        (let ((*generator* (copy new-generator)))
           (setf sequence1 (let (sequence)
                             (dotimes (x 10)
                               (push
                                (random 10)
                                sequence))
                             sequence)))
-        (let ((*random-generator* (copy new-generator)))
+        (let ((*generator* (copy new-generator)))
           (setf sequence2 (let (sequence)
                             (dotimes (x 10)
                               (push
                                (random 10)
                                sequence))
                             sequence)))
-        (fiveam::is (equalp sequence1 sequence2))))))
+        (fiveam::is (equalp sequence1 sequence2))
+        #+nil
+        (sb-ext:gc :full t)))))
 
 ;;; don't love this code, but haven't figured out an alternative.
 (eval-when (:load-toplevel :execute)
   (eval (cons 'progn
-              (loop for gen in (remove 'random-state (list-generator-types))
-                    collect `(repeatable-generator ,(uiop:intern* gen :keyword))))))
+              (loop for gen in (remove 'kiss11 (remove 'random-state (list-generator-types)))
+                    collect `(time (repeatable-generator ,(uiop:intern* gen :keyword)))))))
 
 (defmacro repeatable-generator-no-specials (type)
   (let ((test-name (intern (format nil "~A-RANDOM-REPEATABLE-NO-SPECIALS" type) :random-state-tests)))
@@ -59,13 +60,15 @@
                                (random 10 generator)
                                sequence))
                             sequence)))
-        (fiveam::is (equalp sequence1 sequence2))))))
+        (fiveam::is (equalp sequence1 sequence2))
+        #+nil
+        (sb-ext:gc :full t)))))
 
 ;;; don't love this code, but haven't figured out an alternative.
 (eval-when (:load-toplevel :execute)
   (eval (cons 'progn
-              (loop for gen in (remove 'random-state (list-generator-types))
-                    collect `(repeatable-generator-no-specials ,(uiop:intern* gen :keyword))))))
+              (loop for gen in (remove 'kiss11 (remove 'random-state (list-generator-types)))
+                    collect `(time (repeatable-generator-no-specials ,(uiop:intern* gen :keyword)))))))
 
 
 


### PR DESCRIPTION
These style warnings (which appear for me only on SBCL) are caused by optimizations that the compiler cannot make -- although it is directed to -- because of the order of definitions in the code.