### PR TITLE
Fix RESEED method for RANDOM-STATE on Allegro and Clozure.

### DIFF
--- a/implementation.lisp
+++ b/implementation.lisp
@@ -17,26 +17,16 @@
   #-(or)
   (error "Can't retrieve seed from RANDOM-STATE objects on ~a" (lisp-implementation-type)))
 
-#+sbcl
 (defmethod reseed ((generator random-state) seed)
+  #+sbcl
   (let ((seeded (sb-ext:seed-random-state seed)))
     (replace (sb-kernel::random-state-state generator)
-             (sb-kernel::random-state-state seeded))))
-
-#+ccl
-(defmethod reseed ((generator random-state) seed)
-  (declare (ignorable generator) (ignore seed))
-  (values))
-
-#+allegro
-(defmethod reseed ((generator random-state) seed)
-  (setf (excl::random-state-seed generator) seed))
-
-
-#-(or sbcl ccl allegro)
-(defmethod reseed ((generator random-state) seed)
-  (declare (ignorable generator) (ignore seed))
-  (error "Can't reseed RANDOM-STATE objects on ~a" (lisp-implementation-type)))
+             (sb-kernel::random-state-state seeded)))
+  #+allegro
+  (setf (excl::random-state-seed generator) seed)
+  #-(or allegro sbcl)
+  (warn "Can't reseed RANDOM-STATE objects on ~a" (lisp-implementation-type))
+  generator)
 
 (defmethod next-byte ((generator random-state))
   (cl:random most-positive-fixnum generator))

--- a/implementation.lisp
+++ b/implementation.lisp
@@ -17,12 +17,24 @@
   #-(or)
   (error "Can't retrieve seed from RANDOM-STATE objects on ~a" (lisp-implementation-type)))
 
+#+sbcl
 (defmethod reseed ((generator random-state) seed)
-  #+sbcl ;; Yikes lol.
   (let ((seeded (sb-ext:seed-random-state seed)))
     (replace (sb-kernel::random-state-state generator)
-             (sb-kernel::random-state-state seeded)))
-  #-(or sbcl) #- (or sbcl)
+             (sb-kernel::random-state-state seeded))))
+
+#+ccl
+(defmethod reseed ((generator random-state) seed)
+  (declare (ignorable generator) (ignore seed))
+  (values))
+
+#+allegro
+(defmethod reseed ((generator random-state) seed)
+  (setf (excl::random-state-seed generator) seed))
+
+
+#-(or sbcl ccl allegro)
+(defmethod reseed ((generator random-state) seed)
   (declare (ignorable generator) (ignore seed))
   (error "Can't reseed RANDOM-STATE objects on ~a" (lisp-implementation-type)))
 


### PR DESCRIPTION
For CCL just don't do anything, but don't raise an error because that breaks the build completely on Clozure.

For Allegro, add code using internal functions analogous to the existing method for SBCL.