### PR TITLE
Temporarily remove compiler-macro on Allegro.

### DIFF
--- a/generator.lisp
+++ b/generator.lisp
@@ -17,6 +17,7 @@
 (defun (setf global-generator) (value name)
   (setf (gethash name *generators*) value))
 
+#-allegro
 (define-compiler-macro global-generator (&whole whole name &environment env)
   (if (constantp name env)
       `(load-time-value (or (gethash ,name *generators*)


### PR DESCRIPTION
For some reason the compiler inappropriately applies this on loading.

Somewhat annoying to do this, but it seems relatively harmless and makes random-state load on Allegro 11 (beta). Waiting for fix from Franz.