### PR TITLE
Xorshift docs

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -268,4 +268,81 @@ See https://www.youtube.com/watch?v=LWFzPP8ZbdU")
   (type tt800
     "The predecessor to the Mersenne Twister algorithm.
 
-See http://random.mat.sbg.ac.at/publics/ftp/pub/data/tt800.c"))
+See http://random.mat.sbg.ac.at/publics/ftp/pub/data/tt800.c")
+
+  (type xorshift-32
+    "Linear 32-bit word state shift-register generator.
+
+See https://en.wikipedia.org/wiki/Xorshift
+See https://www.jstatsoft.org/article/view/v008i14")
+
+  (type xorshift-64
+    "The 64-bit variant of the Xorshift algorithm..
+
+See XORSHIFT-32")
+
+  (type xorshift-128
+    "The four times 32-bit word state variant of the Xorshift algorithm.
+
+See XORSHIFT-32")
+
+  (type xorwow
+    "Non-linear five times 32-bit word state shift-register generator.
+
+See XORSHIFT-128
+See https://en.wikipedia.org/wiki/Xorshift#xorwow")
+
+  (type xorshift-64*
+    "Non-linear variation of XORSHIFT-64 by adding a modulo multiplier.
+
+See XORSHIFT-64
+See https://en.wikipedia.org/wiki/Xorshift#xorshift*")
+
+  (type xorshift-1024*
+    "Sixteen 64-bit word state variation of XORSHIFT-64*.
+
+See XORSHIFT-64*")
+
+  (type xorshift-128+
+    "Non-linear double 64-bit state variant of XORSHIFT-64 that's currently the standard on modern browsers' JavaScript engines.
+
+See XORSHIFT-64
+See https://en.wikipedia.org/wiki/Xorshift#xorshift+
+See https://v8.dev/blog/math-random")
+
+  (type xoshiro-128**
+    "32-bit variant of XOSHIRO-256**.
+
+See XOSHIRO-256**
+See https://prng.di.unimi.it/xoshiro128starstar.c")
+
+  (type xoshiro-128++
+    "32-bit variant of XOSHIRO-256++.
+
+See XOSHIRO-256++
+See https://prng.di.unimi.it/xoshiro128plus.c")
+
+  (type xoshiro-128+
+    "32-bit variant of XOSHIRO-256+.
+
+See XOSHIRO-256+
+See https://prng.di.unimi.it/xoshiro128plus.c")
+
+  (type xoshiro-256**
+    "Non-linear rotating general-purpose 64-bit number algorithm.
+
+See https://prng.di.unimi.it/
+See https://prng.di.unimi.it/xoshiro256starstar.c
+See https://en.wikipedia.org/wiki/Xorshift#xoshiro")
+
+  (type xoshiro-256++
+    "A variant of XOSHIRO-256** using addition instead of multiplication.
+
+See XOSHIRO-256**
+See https://prng.di.unimi.it/xoshiro256plusplus.c")
+
+  (type xoshiro-256+
+    "Slightly faster variant of XOSHIRO-256++ meant solely for generating 64-bit floating-point numbers by extracting the upper 53-bits due to the linearity of the lower bits.
+
+See XOSHIRO-256++
+See https://prng.di.unimi.it/xoshiro256plus.c"))

--- a/xorshift.lisp
+++ b/xorshift.lisp
@@ -211,17 +211,25 @@
     (fit-bits 32 (* (xoshiro-rol32 (fit-bits 32 (* (aref values 1) 5)) 7) 9))
     values)))
 
+(define-generator xoshiro-128++ 32 (stateful-generator)
+  ((values (make-array 4 :element-type '(unsigned-byte 32))
+           :type (simple-array (unsigned-byte 32) (4))))
+  (:reseed
+   (setf values (splitmix32-array 4 seed)))
+  (:next ;; Adapted from works by Sebastiano Vigna
+         (%inner-xoshiro
+          32
+          (fit-bits 32 (+ (xoshiro-rol32 (fit-bits 32 (+ (aref values 0) (aref values 3))) 7)
+                          (aref values 0)))
+          values)))
+
 (define-generator xoshiro-128+ 32 (stateful-generator)
     ((values (make-array 4 :element-type '(unsigned-byte 32))
              :type (simple-array (unsigned-byte 32) (4))))
   (:reseed
    (setf values (splitmix32-array 4 seed)))
   (:next ;; Adapted from works by Sebastiano Vigna
-   (%inner-xoshiro
-    32
-    (fit-bits 32 (+ (xoshiro-rol32 (fit-bits 32 (+ (aref values 0) (aref values 3))) 7)
-                    (aref values 0)))
-    values)))
+   (%inner-xoshiro 32 (fit-bits 32 (+ (aref values 0) (aref values 3))) values)))
 
 (define-generator xoshiro-256** 64 (stateful-generator)
     ((values (make-array 4 :element-type '(unsigned-byte 64))
@@ -234,9 +242,9 @@
     (fit-bits 64 (* (xoshiro-rol64 (fit-bits 64 (* (aref values 1) 5)) 7) 9))
     values)))
 
-(define-generator xoshiro-256+ 64 (stateful-generator)
-    ((values (make-array 4 :element-type '(unsigned-byte 64))
-              :type (simple-array (unsigned-byte 64) (4))))
+(define-generator xoshiro-256++ 64 (stateful-generator)
+  ((values (make-array 4 :element-type '(unsigned-byte 64))
+           :type (simple-array (unsigned-byte 64) (4))))
   (:reseed
    (setf values (splitmix64-array 4 seed)))
   (:next ;; Adapted from works by Sebastiano Vigna
@@ -245,3 +253,11 @@
     (fit-bits 64 (+ (xoshiro-rol64 (fit-bits 64 (+ (aref values 0) (aref values 3))) 23)
                     (aref values 0)))
     values)))
+
+(define-generator xoshiro-256+ 64 (stateful-generator)
+  ((values (make-array 4 :element-type '(unsigned-byte 64))
+           :type (simple-array (unsigned-byte 64) (4))))
+  (:reseed
+   (setf values (splitmix64-array 4 seed)))
+  (:next ;; Adapted from works by Sebastiano Vigna
+   (%inner-xoshiro 64 (fit-bits 64 (+ (aref values 0) (aref values 3))) values)))

--- a/xorshift.lisp
+++ b/xorshift.lisp
@@ -212,16 +212,16 @@
     values)))
 
 (define-generator xoshiro-128++ 32 (stateful-generator)
-  ((values (make-array 4 :element-type '(unsigned-byte 32))
-           :type (simple-array (unsigned-byte 32) (4))))
+    ((values (make-array 4 :element-type '(unsigned-byte 32))
+             :type (simple-array (unsigned-byte 32) (4))))
   (:reseed
    (setf values (splitmix32-array 4 seed)))
   (:next ;; Adapted from works by Sebastiano Vigna
-         (%inner-xoshiro
-          32
-          (fit-bits 32 (+ (xoshiro-rol32 (fit-bits 32 (+ (aref values 0) (aref values 3))) 7)
-                          (aref values 0)))
-          values)))
+   (%inner-xoshiro
+    32
+    (fit-bits 32 (+ (xoshiro-rol32 (fit-bits 32 (+ (aref values 0) (aref values 3))) 7)
+                    (aref values 0)))
+    values)))
 
 (define-generator xoshiro-128+ 32 (stateful-generator)
     ((values (make-array 4 :element-type '(unsigned-byte 32))
@@ -233,7 +233,7 @@
 
 (define-generator xoshiro-256** 64 (stateful-generator)
     ((values (make-array 4 :element-type '(unsigned-byte 64))
-              :type (simple-array (unsigned-byte 64) (4))))
+             :type (simple-array (unsigned-byte 64) (4))))
   (:reseed
    (setf values (splitmix64-array 4 seed)))
   (:next ;; Adapted from works by Sebastiano Vigna
@@ -243,8 +243,8 @@
     values)))
 
 (define-generator xoshiro-256++ 64 (stateful-generator)
-  ((values (make-array 4 :element-type '(unsigned-byte 64))
-           :type (simple-array (unsigned-byte 64) (4))))
+    ((values (make-array 4 :element-type '(unsigned-byte 64))
+             :type (simple-array (unsigned-byte 64) (4))))
   (:reseed
    (setf values (splitmix64-array 4 seed)))
   (:next ;; Adapted from works by Sebastiano Vigna
@@ -255,8 +255,8 @@
     values)))
 
 (define-generator xoshiro-256+ 64 (stateful-generator)
-  ((values (make-array 4 :element-type '(unsigned-byte 64))
-           :type (simple-array (unsigned-byte 64) (4))))
+    ((values (make-array 4 :element-type '(unsigned-byte 64))
+             :type (simple-array (unsigned-byte 64) (4))))
   (:reseed
    (setf values (splitmix64-array 4 seed)))
   (:next ;; Adapted from works by Sebastiano Vigna


### PR DESCRIPTION
I noticed that I forgot to include documentation for the Xorshift PRNG's. This PR also fixes an issue where Xoroshiro-128/256++ generators were named Xoroshiro-128/256+. I also included the actual Xoroshiro-128/256+ generators.