### PR TITLE
Tweaks to build cleanly

### DIFF
--- a/implementation.lisp
+++ b/implementation.lisp
@@ -18,7 +18,8 @@
              (sb-kernel::random-state-state seeded)))
   #+allegro
   (setf (excl::random-state-seed generator) seed)
-  #-(or allegro sbcl)
+  #-(or allegro sbcl)   #-(or allegro sbcl)
+  (declare (ignorable seed))
   (warn "Can't reseed RANDOM-STATE objects on ~a" (lisp-implementation-type))
   generator)
 


### PR DESCRIPTION
Avoid a compiler warning in CCL.
More importantly, change definition orderings in "protocol.lisp" to be consistent with declarations.  Move a compiler-macro up before the first invocation of its function.  Move the `random` function before its first use as it's declared inline.