### PR TITLE
Draft: More reorderings and one `notinline` declaration.

### DIFF
--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -77,6 +77,7 @@
               :initial-contents thing))
 
 (defun histogram (rng bins &key (samples (floor 1e8)) (width 80) (stream *standard-output*))
+  (declare (notinline random))
   (check-type samples (unsigned-byte 64))
   (let ((histogram (make-array bins))
         (sample-contribution (/ samples))


### PR DESCRIPTION
I needed to pull another compiler macro forward and add a notinline declaration into toolkit.

Possibly for the latter a better fix would be to pull the histogram code out and put it in a file later in the ASDF system.