### PR TITLE
Move COPY method definitions.

### DIFF
--- a/generator.lisp
+++ b/generator.lisp
@@ -80,6 +80,18 @@
 (defun multivariate-p (generator)
   (listp (bits-per-byte generator)))
 
+;;; supporting methods for COPY
+(defmethod copy ((thing number))
+  thing)
+
+(defmethod copy ((thing array))
+  (make-array (array-dimensions thing)
+              :element-type (array-element-type thing)
+              :fill-pointer (array-has-fill-pointer-p thing)
+              :adjustable (adjustable-array-p thing)
+              :initial-contents thing))
+
+
 (defun make-generator (type &optional (seed T) &rest initargs)
   (let ((generator (apply #'%make-generator type initargs)))
     (when seed (reseed generator seed))

--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -66,16 +66,6 @@
 (defmacro update (bits place op &rest args)
   `(setf ,place (fit-bits ,bits (,op ,place ,@args))))
 
-(defmethod copy ((thing number))
-  thing)
-
-(defmethod copy ((thing array))
-  (make-array (array-dimensions thing)
-              :element-type (array-element-type thing)
-              :fill-pointer (array-has-fill-pointer-p thing)
-              :adjustable (adjustable-array-p thing)
-              :initial-contents thing))
-
 
 (defun list-dim (list)
   (list* (length list)


### PR DESCRIPTION
There were default `copy` method definitions in the file toolkit.lisp that was loaded before the (macro-generated) `defgeneric` for `copy`, in generator.lisp.

This made SBCL grumpy, so I moved the two `copy` method definitions into generator.lisp.