### PR TITLE
Fix the GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,17 @@ jobs:
     strategy:
       matrix:
         # clisp doesn't run on ubuntu VMs currently
-        lisp: [sbcl-bin,sbcl,ccl,ccl32,ecl,allegro,cmucl,abcl]
+        lisp: [sbcl-bin,ccl-bin/1.12.2,ecl,allegro/10.1express,cmu-bin/21e,abcl/1.9.2]
         os: [ubuntu-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       
     - name: cache .roswell
       id: cache-dot-roswell
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.roswell
         key: ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-${{ hashFiles('**/*.asd') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: prepare
+      uses: 40ants/setup-lisp@v2
+      with:
+        roswell-version: v22.12.14.113
+        asdf-version: 3.3.6
     - uses: actions/checkout@v3
       
     - name: cache .roswell
@@ -29,11 +34,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-
           ${{ runner.os }}-dot-roswell-
-
-    - name: install roswell
-      env:
-       LISP: ${{ matrix.lisp }}
-      run: curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh -x
 
     - name: install parachute
       run: |


### PR DESCRIPTION
Fix up problems from changes in Roswell, GitHub actions, etc.

Update the versions of the actions we use: cache and checkout.

Use 40ants/setup-lisp to install roswell instead of doing it myself, by hand.

Specify the lisp versions to install with roswell.