### PR TITLE
Add a test to check and see if RANDOM-STATE builds cleanly

### DIFF
--- a/.github/workflows/build-clean-test.yml
+++ b/.github/workflows/build-clean-test.yml
@@ -1,0 +1,46 @@
+name: build-clean-test
+
+on:
+  push:
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: ${{ matrix.lisp }} on ${{ matrix.os }}
+    strategy:
+      matrix:
+        # clisp doesn't run on ubuntu VMs currently
+        lisp: [sbcl-bin,ccl-bin/1.12.2,ecl,allegro/10.1express,cmu-bin/21e,abcl/1.9.2]
+        os: [ubuntu-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: prepare
+      uses: 40ants/setup-lisp@v2
+      with:
+        roswell-version: v22.12.14.113
+        asdf-version: 3.3.6
+
+    - uses: actions/checkout@v3
+
+    - name: cache .roswell
+      id: cache-dot-roswell
+      uses: actions/cache@v3
+      with:
+        path: ~/.roswell
+        key: ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-${{ hashFiles('**/*.asd') }}
+        restore-keys: |
+          ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-
+          ${{ runner.os }}-dot-roswell-
+
+    - name: update ql dist if we have one cached
+      shell: bash
+      run: ros -e "(ql:update-all-dists :prompt nil)"
+
+    - name: test for clean build
+      shell: bash
+      run: |
+        ros run -l "do-test.lisp"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,17 @@ jobs:
     strategy:
       matrix:
         # clisp doesn't run on ubuntu VMs currently
-        lisp: [sbcl-bin,sbcl,ccl,ccl32,ecl,allegro,cmucl,abcl]
+        lisp: [sbcl-bin,ccl-bin/1.12.2,ecl,allegro/10.1express,cmu-bin/21e,abcl/1.9.2]
         os: [ubuntu-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       
     - name: cache .roswell
       id: cache-dot-roswell
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.roswell
         key: ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-${{ hashFiles('**/*.asd') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: prepare
+      uses: 40ants/setup-lisp@v2
+      with:
+        roswell-version: v22.12.14.113
+        asdf-version: 3.3.6
     - uses: actions/checkout@v3
       
     - name: cache .roswell
@@ -29,11 +34,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-
           ${{ runner.os }}-dot-roswell-
-
-    - name: install roswell
-      env:
-       LISP: ${{ matrix.lisp }}
-      run: curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh -x
 
     - name: install parachute
       run: |

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -1,0 +1,48 @@
+#|
+ This file is a part of random-state
+ (c) 2023 Robert P. Goldman and SIFT, LLC
+ Author: Robert P. Goldman <rpgoldman@sift.net>
+|#
+
+
+(in-package :common-lisp-user)
+
+(defpackage test-random-state
+  (:use :common-lisp))
+
+(in-package :test-random-state)
+
+(load (merge-pathnames (make-pathname :directory '(:relative "quicklisp") :name "setup" :type "lisp")
+                       (user-homedir-pathname)))
+
+(push (namestring (uiop:pathname-directory-pathname *load-truename*)) ql:*local-project-directories*)
+(ql:quickload "documentation-utils")
+
+(handler-case
+ (assert (uiop:pathname-equal (asdf:component-pathname (asdf:find-system "random-state"))
+                              (uiop:pathname-directory-pathname *load-truename*)))
+  (error () (uiop:die 2 "Not loading RANDOM-STATE from the expected location.")))
+
+;;; check for clean build
+(let (warnings style-warnings)
+ (handler-bind
+     ((style-warning #'(lambda (x)
+                         (push x style-warnings)))
+      (warning #'(lambda (x)
+                   (unless (typep x 'style-warning)
+                     (push x warnings))))
+      (error #'(lambda (c) (uiop:die 3 "Failed to build with error:~%~T~a" c))))
+   (ql:quickload "random-state" :silent nil :verbose t))
+  (when warnings
+    (format t "Failed to build cleanly: got WARNINGs:~%~{~t~a~%~}" warnings))
+  (when style-warnings
+    (format t "Failed to build cleanly: got STYLE-WARNINGs:~%~{~t~a~%~}" style-warnings))
+  (when (or warnings style-warnings)
+   (uiop:die 3 "Failed to build cleanly: got ~a"
+             (cond ((and warnings style-warnings)
+                    "warnings and style warnings")
+                   (warnings "warnings")
+                   (style-warnings "style warnings")))))
+
+
+(uiop:quit 0)

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -14,8 +14,11 @@
 
 (handler-bind ((error #'(lambda (c)
                           (uiop:die 4 "Error setting up for build: ~a" c))))
-  (load (merge-pathnames (make-pathname :directory '(:relative "quicklisp") :name "setup" :type "lisp")
-                         (user-homedir-pathname)))
+  ;; if we are running in roswell, we already have quicklisp installed and it's likely not in a normal
+  ;; location.
+  (unless (find-package :ql)
+    (load (merge-pathnames (make-pathname :directory '(:relative "quicklisp") :name "setup" :type "lisp")
+                           (user-homedir-pathname))))
 
   (push (namestring (uiop:pathname-directory-pathname *load-truename*)) (symbol-value (uiop:intern* '#:*local-project-directories* :ql)))
   (uiop:symbol-call :ql 'quickload "documentation-utils"))

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -12,11 +12,13 @@
 
 (in-package :test-random-state)
 
-(load (merge-pathnames (make-pathname :directory '(:relative "quicklisp") :name "setup" :type "lisp")
-                       (user-homedir-pathname)))
+(handler-bind ((error #'(lambda (c)
+                          (uiop:die 4 "Error setting up for build: ~a" c))))
+  (load (merge-pathnames (make-pathname :directory '(:relative "quicklisp") :name "setup" :type "lisp")
+                         (user-homedir-pathname)))
 
-(push (namestring (uiop:pathname-directory-pathname *load-truename*)) ql:*local-project-directories*)
-(ql:quickload "documentation-utils")
+  (push (namestring (uiop:pathname-directory-pathname *load-truename*)) (symbol-value (uiop:intern* '#:*local-project-directories* :ql)))
+  (uiop:symbol-call :ql 'quickload "documentation-utils"))
 
 (handler-case
  (assert (uiop:pathname-equal (asdf:component-pathname (asdf:find-system "random-state"))


### PR DESCRIPTION
Check to make sure that `random-state` builds w/o warnings on a wide variety of systems.

Interestingly, while this test passes for me locally, it *fails* when run as a GitHub action, with redefinition warnings on all lisps.  Not sure why this is happening. @Shinmera any clue?

```
Failed to build cleanly: got STYLE-WARNINGs:
 redefining RANDOM-STATE::%INNER-XOSHIRO in DEFMACRO
 redefining RANDOM-STATE::%XORSHIFT in DEFMACRO
 redefining RANDOM-STATE::%INNER-MERSENNE-TWISTER in DEFMACRO
 redefining RANDOM-STATE:DEFINE-GENERATOR in DEFMACRO
 redefining RANDOM-STATE:COPY in DEFGENERIC
 redefining RANDOM-STATE::DEFINE-GENERATOR-FUN in DEFMACRO
 redefining RANDOM-STATE::UPDATE in DEFMACRO
 redefining RANDOM-STATE::INCFMOD in DEFMACRO
```