### PR TITLE
fix pcg so it matches reference

### DIFF
--- a/pcg.lisp
+++ b/pcg.lisp
@@ -11,7 +11,8 @@
    (pcg-next generator))
   (:next
    (let ((oldstate state))
-     (setf state (fit-bits 64 (+ (fit-bits 64 (* oldstate #x6364136223846793005)) inc)))
-     (let ((xord (ash (logxor (ash oldstate -18) oldstate) -27))
-           (rot (ash oldstate -59)))
+     (setf state (fit-bits 64 (+ (fit-bits 64 (* oldstate 6364136223846793005)) inc)))
+     (let ((xord (fit-bits 32 (ash (logxor (ash oldstate -18) oldstate) -27)))
+           (rot (fit-bits 32 (ash oldstate -59))))
        (fit-bits 32 (logior (ash xord (- rot)) (ash xord (logand (- rot) 31))))))))
+

--- a/test.lisp
+++ b/test.lisp
@@ -44,3 +44,16 @@
 (define-default-rng-test random:xoshiro-128+)
 (define-default-rng-test random:xoshiro-256**)
 (define-default-rng-test random:xoshiro-256+)
+
+(define-test pcg-ref ;; compare to values from reference implementation
+  (let ((r (random:make-generator 'random:pcg)))
+    (finish (random::pcg-reseed r 123))
+    (is = #xa672e978b011d001 (random::pcg-state r))
+    (is = 247 (random::pcg-inc r))
+    (is = #x81c81ce5 (random::pcg-next r))
+    (is = #x49e9aca3 (random::pcg-next r))
+    (dotimes (i 30) (random::pcg-next r))
+    (is = #x3c67e995 (random::pcg-next r))
+    (is = #xd4b18bfdfb1841c4 (random::pcg-state r))
+    (is = 247 (random::pcg-inc r))))
+


### PR DESCRIPTION
Random points in ±1.0 had obvious banding (same code looked fine with other generators).

With fix, looks better and matches reference implementation in https://github.com/imneme/pcg-c-basic/blob/master/pcg_basic.c (at least for the 32 values of the 1 seed i tried).