### PR TITLE
Build clean on SBCL.

### DIFF
--- a/generator.lisp
+++ b/generator.lisp
@@ -107,7 +107,7 @@
          (index (intern* 'index)))
     `(progn
        (pushnew ',name *generator-types*)
-       
+
        (defstruct (,name
                    (:include ,@super)
                    (:constructor ,constructor)
@@ -129,6 +129,8 @@
                                     (,reseed ,generator new-seed))))
                          (:next
                           `(progn (defun ,next (,generator)
+                                    ;; sometimes argument is not used.
+                                    (declare (ignorable ,generator))
                                     (symbol-macrolet ,bindings
                                       ,@body))
                                   (defmethod next-byte ((,generator ,name))
@@ -157,6 +159,8 @@
 
        ,@(unless (find :copy bodies :key #'car)
            `((defun ,copy (,generator)
+               ;; sometimes the argument is not used.
+               (declare (ignorable ,generator))
                (,constructor ,@(loop for binding in bindings
                                      collect (intern (string (first binding)) "KEYWORD")
                                      collect `(copy ,(second binding)))))))

--- a/protocol.lisp
+++ b/protocol.lisp
@@ -43,12 +43,15 @@
      (random-int generator 0 (1- max)))
     ((short-float 0s0)
      (random-float generator 0s0 (- max short-float-epsilon)))
-    #-ccl ; apparently ccl's SHORT-FLOAT and SINGLE-FLOAT are the same
+    ;; apparently ccl's SHORT-FLOAT and SINGLE-FLOAT are the same
+    ;; and also on SBCL, at least on new Mac chips.
+    #-(or ccl (and sbcl darwin arm64))
     ((single-float 0f0)
      (random-float generator 0f0 (- max single-float-epsilon)))
     ((double-float 0d0)
      (random-float generator 0d0 (- max double-float-epsilon)))
-    #-ccl ; apparently ccl's LONG-FLOAT and DOUBLE-FLOAT are the same
+    ;; see SINGLE-FLOAT comment
+    #-(or ccl (and sbcl darwin arm64))
     ((long-float 0l0)
      (random-float generator 0l0 (- max long-float-epsilon)))))
 

--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -116,6 +116,10 @@
     histogram))
 
 (defun benchmark (rng &key (samples 1000000) (stream *standard-output*))
+  ;; this declaration is necessary because ENSURE-GENERATOR is a
+  ;; forward-reference and SBCL does not like it that it misses the
+  ;; chance to apply the compiler macro here. [2024/07/29:rpg]
+  (declare (notinline ensure-generator))
   (let* ((rng (ensure-generator rng))
          (next-fun (next-byte-fun rng))
          (start (get-internal-run-time)))


### PR DESCRIPTION
Resolve all style warnings.

Quash warning from toolkit.lisp use of ENSURE-GENERATOR before its compiler macro has been defined.

Modify handling of shadowed types in protocol.lisp.  There were declarations for this for CCL. Added them for MacOS SBCL.

Added IGNORABLE declarations for possibly-unused arguments in generator.lisp.

Even after this, there are still some style-warnings about redefined macros. I will post those in an issue.