### PR TITLE
Define ASDF:TEST-OP on RANDOM-STATE system.

### DIFF
--- a/random-state.asd
+++ b/random-state.asd
@@ -6,6 +6,7 @@
   :homepage "https://Shinmera.github.io/random-state/"
   :bug-tracker "https://github.com/Shinmera/random-state/issues"
   :source-control (:git "https://github.com/Shinmera/random-state.git")
+  :in-order-to ((test-op (test-op "random-state-test")))
   :serial T
   :components ((:file "package")
                (:file "toolkit")


### PR DESCRIPTION
Now `(asdf:test-system "random-state")` will delegate testing to the
"random-state-test" system, instead of requiring the user to remember to
`(asdf:test-system "random-state-test")` (which will still work).
