### PR TITLE
Changes to make the CCL compiler happy

### DIFF
--- a/generator.lisp
+++ b/generator.lisp
@@ -140,7 +140,7 @@
                          (:hash
                           `(progn (defun ,hash (,index ,seed ,@(mapcar #'first bindings))
                                     (declare (type (unsigned-byte 64) ,index ,seed))
-                                    (declare ,@(loop for (slot _ . args) in slots
+                                    (declare ,@(loop for (slot nil . args) in slots
                                                      collect `(type ,(getf args :type T) ,slot)))
                                     ,@body)
                                   (defmethod hash ((,generator ,name) ,index ,seed)

--- a/histogram.lisp
+++ b/histogram.lisp
@@ -36,3 +36,33 @@
              (incf total (abs deviation)))
     (format stream "Cumulative deviation: ~6,3f%~%" total)
     histogram))
+
+
+(defun benchmark (rng &key (samples 1000000) (stream *standard-output*))
+  ;; this declaration is necessary because ENSURE-GENERATOR is a
+  ;; forward-reference and SBCL does not like it that it misses the
+  ;; chance to apply the compiler macro here. [2024/07/29:rpg]
+  (let* ((rng (ensure-generator rng))
+         (next-fun (next-byte-fun rng))
+         (start (get-internal-run-time)))
+    (declare (type (unsigned-byte 64) samples))
+    (declare (type (function (generator) T) next-fun))
+    (locally (declare (optimize speed (safety 0)))
+      (loop repeat samples
+            do (funcall next-fun rng)))
+    (let* ((end (get-internal-run-time))
+           (duration (float (/ (- end start) INTERNAL-TIME-UNITS-PER-SECOND) 0d0)))
+      (format stream "Duration: ~12t~10,1f~%Samples: ~12t~10d~%Samples/s: ~12t~10,1f~%S/sample: ~12t~10,8f"
+              duration samples (/ samples duration) (/ duration samples))
+      (/ samples duration))))
+
+(defun benchmark-all (&key (samples 1000000) (stream *standard-output*))
+  (let* ((nullstream (make-broadcast-stream))
+         (stats (loop for rng in (list-generator-types)
+                      for result = (cons rng (handler-case (benchmark rng :samples samples :stream nullstream)
+                                               (error () -1)))
+                      when result collect result)))
+    (setf stats (sort stats #'> :key #'cdr))
+    (format stream "RNG~20tSamples/second~%")
+    (loop for (rng . samples) in stats
+          do (format stream "~&~a~20t~18,1f~%" rng samples))))

--- a/sobol.lisp
+++ b/sobol.lisp
@@ -759,7 +759,6 @@
      (loop for i from 1 below dim
            for a = (aref sobol-a (1- i))
            for d = 0
-           for k = 0
            do (loop while (< 0 a)
                     do (incf d)
                        (setf a (ash a -1)))

--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -76,35 +76,6 @@
               :adjustable (adjustable-array-p thing)
               :initial-contents thing))
 
-(defun benchmark (rng &key (samples 1000000) (stream *standard-output*))
-  ;; this declaration is necessary because ENSURE-GENERATOR is a
-  ;; forward-reference and SBCL does not like it that it misses the
-  ;; chance to apply the compiler macro here. [2024/07/29:rpg]
-  (declare (notinline ensure-generator))
-  (let* ((rng (ensure-generator rng))
-         (next-fun (next-byte-fun rng))
-         (start (get-internal-run-time)))
-    (declare (type (unsigned-byte 64) samples))
-    (declare (type (function (generator) T) next-fun))
-    (locally (declare (optimize speed (safety 0)))
-      (loop repeat samples
-            do (funcall next-fun rng)))
-    (let* ((end (get-internal-run-time))
-           (duration (float (/ (- end start) INTERNAL-TIME-UNITS-PER-SECOND) 0d0)))
-      (format stream "Duration: ~12t~10,1f~%Samples: ~12t~10d~%Samples/s: ~12t~10,1f~%S/sample: ~12t~10,8f"
-              duration samples (/ samples duration) (/ duration samples))
-      (/ samples duration))))
-
-(defun benchmark-all (&key (samples 1000000) (stream *standard-output*))
-  (let* ((nullstream (make-broadcast-stream))
-         (stats (loop for rng in (list-generator-types)
-                      for result = (cons rng (handler-case (benchmark rng :samples samples :stream nullstream)
-                                               (error () -1)))
-                      when result collect result)))
-    (setf stats (sort stats #'> :key #'cdr))
-    (format stream "RNG~20tSamples/second~%")
-    (loop for (rng . samples) in stats
-          do (format stream "~&~a~20t~18,1f~%" rng samples))))
 
 (defun list-dim (list)
   (list* (length list)


### PR DESCRIPTION
Move the `benchmark` functions from "toolkit.lisp" to "histogram.lisp" (if you prefer, these could instead be moved to a new "benchmark.lisp").  These functions make reference to stuff that is defined in generator.lisp, which is loaded downstream, causing CCL heartburn.

Also, two minor changes tweaking declarations that make CCL happier.