### PR TITLE
Update the GitHub CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # clisp doesn't run on ubuntu VMs currently
-        lisp: [sbcl-bin,ccl-bin/1.12.2,ecl,allegro/10.1express,cmu-bin/21e,abcl/1.9.2]
+        lisp: [sbcl-bin,ccl-bin,ecl,allegro,cmu-bin/21e,abcl/1.9.2]
         os: [ubuntu-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,4 @@ jobs:
     - name: load code and run tests
       shell: bash
       run: |
-        run-parachute -l "random-state-test" "org.shirakumo.random-state.test"
+        run-parachute -l "random-state/test" "org.shirakumo.random-state.test"


### PR DESCRIPTION
GitHub scripts were out-of-date with respect to the ASDF system definition and the set of lisp implementations available from Roswell.